### PR TITLE
Add tooltip about depth setting in marine

### DIFF
--- a/R/ui-functions.R
+++ b/R/ui-functions.R
@@ -1,4 +1,4 @@
-chem_input <- function(id){
+chem_input <- function(id) {
   selectInput(
     id,
     "Select a chemical:",
@@ -31,7 +31,10 @@ doc_input <- function(id, label_prefix = NULL) {
 depth_input <- function(id, label_prefix = NULL) {
   numericInput(
     id,
-    add_prefix("Water Depth (m)", label_prefix),
+    input_tooltip(
+      add_prefix("Water Depth (m)", label_prefix),
+      "Set depth to 0.01m for marine environments"
+    ),
     value = 0.25
   )
 }


### PR DESCRIPTION
The tooltip looks like this when hovering over it:

![image](https://github.com/user-attachments/assets/44029527-1f10-4c2e-986b-a971250154b3)
